### PR TITLE
Create a bind mountable workspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ RUN groupadd --gid $USERID $USERNAME && \
 
 # Instalar paquetes de linux de manera desatendida
 RUN apt-get update && apt-get install -y \
-nano \
-terminator \
-wget \
-unzip
+    nano \
+    terminator \
+    wget \
+    unzip
 
 RUN apt-get install python3-pip -y
 RUN pip3 install pynput
@@ -50,23 +50,21 @@ RUN mkdir /home/${USERNAME}/.gazebo
 ADD gazebo_resources.tar.xz /home/${USERNAME}/.gazebo/
 
 # Crear el workspace gazebo_ws (no probado)
-RUN mkdir -p  /tmp/curso_ros/gazebo_ws/src
-WORKDIR /tmp/curso_ros/gazebo_ws
-RUN /bin/bash -c '. /opt/ros/noetic/setup.bash; cd /tmp/curso_ros/gazebo_ws; catkin_make'
+RUN mkdir -p  /opt/curso_ros/gazebo_ws/src
+WORKDIR /opt/curso_ros/gazebo_ws
+RUN /bin/bash -c '. /opt/ros/noetic/setup.bash; cd /opt/curso_ros/gazebo_ws; catkin_make'
 
 # Descomprimir modelos navegación jetbot y lo configuramos
-ADD jetbot_ws.zip /tmp/curso_ros/gazebo_ws/src
-RUN unzip /tmp/curso_ros/gazebo_ws/src/jetbot_ws.zip -d /tmp/curso_ros/gazebo_ws/src
-RUN ls -lh /tmp/curso_ros/gazebo_ws/src
-RUN mv /tmp/curso_ros/gazebo_ws/src/jetbot_diff_drive/jetbot_navigation /tmp/
-#RUN rm -rf $HOME/curso_ros/gazebo_ws/src/jetbot_diff_drive/jetbot_navigation
+ADD jetbot_ws.zip /opt/curso_ros/gazebo_ws/src
+RUN unzip /opt/curso_ros/gazebo_ws/src/jetbot_ws.zip -d /opt/curso_ros/gazebo_ws/src
+RUN mv /opt/curso_ros/gazebo_ws/src/jetbot_diff_drive/jetbot_navigation /tmp/
 COPY catkin_workspace.cmake /opt/ros/noetic/share/catkin/cmake/
-RUN /bin/bash -c '. /opt/ros/noetic/setup.bash; cd /tmp/curso_ros/gazebo_ws; catkin_make'
-RUN mv /tmp/jetbot_navigation /tmp/curso_ros/gazebo_ws/src/jetbot_diff_drive/
+RUN /bin/bash -c '. /opt/ros/noetic/setup.bash; cd /opt/curso_ros/gazebo_ws; catkin_make'
+RUN mv /tmp/jetbot_navigation /opt/curso_ros/gazebo_ws/src/jetbot_diff_drive/
 
-# Cambiar el propietario de las carpetas /tmp/curso_ros y /home/${USERNAME}/.gazebo
-# a $USERNAME
-RUN chown -R ${USERNAME}:${USERNAME} /tmp/curso_ros
+# Cambiar el propietario de las carpetas /opt/curso_ros
+# y /home/${USERNAME}/.gazebo a $USERNAME
+RUN chown -R ${USERNAME}:${USERNAME} /opt/curso_ros
 RUN chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.gazebo
 
 # Añadir el usuario $USERNAME al grupo vídeo

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,23 +49,41 @@ RUN mkdir /home/${USERNAME}/.gazebo
 # Descomprimir mundos y modelos para gazebo
 ADD gazebo_resources.tar.xz /home/${USERNAME}/.gazebo/
 
-# Crear el workspace gazebo_ws (no probado)
-RUN mkdir -p  /opt/curso_ros/gazebo_ws/src
-WORKDIR /opt/curso_ros/gazebo_ws
-RUN /bin/bash -c '. /opt/ros/noetic/setup.bash; cd /opt/curso_ros/gazebo_ws; catkin_make'
+# Crear el workspace
+ARG INIT_WORKDIR_FOLDER=/init_workspace
+ARG WORKDIR_FOLDER=/workspace
+RUN mkdir -p ${INIT_WORKDIR_FOLDER}/src
+RUN mkdir -p ${WORKDIR_FOLDER}
+WORKDIR ${INIT_WORKDIR_FOLDER}
+RUN /bin/bash -c '. /opt/ros/noetic/setup.bash; cd ${INIT_WORKDIR_FOLDER}; catkin_make'
 
 # Descomprimir modelos navegación jetbot y lo configuramos
-ADD jetbot_ws.zip /opt/curso_ros/gazebo_ws/src
-RUN unzip /opt/curso_ros/gazebo_ws/src/jetbot_ws.zip -d /opt/curso_ros/gazebo_ws/src
-RUN mv /opt/curso_ros/gazebo_ws/src/jetbot_diff_drive/jetbot_navigation /tmp/
+ADD jetbot_ws.zip ${INIT_WORKDIR_FOLDER}/src
+RUN unzip ${INIT_WORKDIR_FOLDER}/src/jetbot_ws.zip -d ${INIT_WORKDIR_FOLDER}/src
+RUN mv ${INIT_WORKDIR_FOLDER}/src/jetbot_diff_drive/jetbot_navigation /tmp/
 COPY catkin_workspace.cmake /opt/ros/noetic/share/catkin/cmake/
-RUN /bin/bash -c '. /opt/ros/noetic/setup.bash; cd /opt/curso_ros/gazebo_ws; catkin_make'
-RUN mv /tmp/jetbot_navigation /opt/curso_ros/gazebo_ws/src/jetbot_diff_drive/
+RUN /bin/bash -c '. /opt/ros/noetic/setup.bash; cd ${INIT_WORKDIR_FOLDER}; catkin_make'
+RUN mv /tmp/jetbot_navigation ${INIT_WORKDIR_FOLDER}/src/jetbot_diff_drive/
 
-# Cambiar el propietario de las carpetas /opt/curso_ros
+# Cambiar el propietario de las carpetas ${INIT_WORKDIR_FOLDER}, ${WORKDIR_FOLDER}
 # y /home/${USERNAME}/.gazebo a $USERNAME
-RUN chown -R ${USERNAME}:${USERNAME} /opt/curso_ros
+RUN chown -R ${USERNAME}:${USERNAME} ${INIT_WORKDIR_FOLDER}
+RUN chown -R ${USERNAME}:${USERNAME} ${WORKDIR_FOLDER}
 RUN chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.gazebo
 
-# Añadir el usuario $USERNAME al grupo vídeo
+# Añadir el usuario $USERNAME al grupo video
 RUN addgroup ${USERNAME} video
+
+# Copiar script de sincronización
+ADD workspace-sync.sh /app/workspace-sync.sh
+RUN chown ${USERNAME}:${USERNAME} /app/workspace-sync.sh
+RUN chmod 755 /app/workspace-sync.sh
+
+# Cambiar el usuario a $USERNAME
+USER ${USERNAME}
+
+# Cambiar el directorio de trabajo a ${WORKDIR_FOLDER}
+WORKDIR ${WORKDIR_FOLDER}
+
+# Ejecutar el script de sincronización al iniciar el contenedor
+ENTRYPOINT [ "/app/workspace-sync.sh" ]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker run --name rosGazeboJebotNET -it \
 --device=/dev/dri:/dev/dri \
 --device=/dev/snd:/dev/snd \
 --privileged -v /dev/bus/usb:/dev/bus/usb \
--v $HOME/curso_ros/:/tmp/curso_ros/:rw \
+-v $HOME/curso_ros/:/workspace/:rw \
 -v /tmp/.X11-unix:/tmp/.X11-unix \
 --net=host \
 --env="QT_X11_NO_MITSHM=1" \

--- a/workspace-sync.sh
+++ b/workspace-sync.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+INIT_WORKSPACE_FOLDER=/init_workspace
+WORKSPACE_FOLDER=/workspace
+
+user=$(whoami)
+
+if ! [[ "$(ls -A ${WORKSPACE_FOLDER})" ]]; then
+  sudo cp -R ${INIT_WORKSPACE_FOLDER}/* ${WORKSPACE_FOLDER}
+  sudo chown -R ${user}:${user} ${WORKSPACE_FOLDER}
+fi
+
+exec "$@"


### PR DESCRIPTION
This pull request:

- Creates a **/init_workspace** folder where the initial workspace is build (previous /tmp/curso_ros/gazebo_ws)
- Creates an empty **/workspace** folder that will be used as the working directory
- Adds a **workspace-sync.sh** script that copies the /init_workspace content to /workspace on the first launch
- Updates the README.md file

@poxtius @ionhs @LaraBurgoa Orain bai, lortu dut (ordu dexente sartu dizkiot, hori bai 😢)

Signed-off-by: Aitor Iturrioz <aiturrioz@tknika.eus>